### PR TITLE
Set default options in beforeAction() instead of in init()

### DIFF
--- a/controllers/ConsumerController.php
+++ b/controllers/ConsumerController.php
@@ -66,7 +66,12 @@ class ConsumerController extends Controller
     public function init()
     {
         \Yii::$app->rabbitmq->load();
+    }
+
+    public function beforeAction($event)
+    {
         $this->setOptions();
+        return parent::beforeAction($event);
     }
 
     /**


### PR DESCRIPTION
Hi there!

Thank you for writing this very useful library. 

Options passed in the console are not available yet during the init phase. Therefore I suggest to parse the options in `beforeAction()`.