### PR TITLE
Fix bug in `logError()` when instance of `\Error` is thrown

### DIFF
--- a/components/Consumer.php
+++ b/components/Consumer.php
@@ -287,12 +287,12 @@ class Consumer extends BaseConsumer
     }
 
     /**
-     * @param \Exception $e
+     * @param \Throwable $e
      * @param $queueName
      * @param AMQPMessage $msg
      * @param $timeStart
      */
-    private function logError(\Exception $e, $queueName, AMQPMessage $msg, $timeStart)
+    private function logError($e, $queueName, AMQPMessage $msg, $timeStart)
     {
         \Yii::error([
             'msg' => $e->getMessage(),


### PR DESCRIPTION
Since PHP7 internal php errors are thrown as instances of `\Error` which is not
an instance of `\Exception`. Both `\Error` and `\Exception` are instance of `\Throwable`.
As `\Throwable` is not available in PHP<7 there is no way to type hint for both
\Error and \Exception if you want to be compatible with PHP<7.