### PR TITLE
Event before_publish and after_pusblish

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ return [
 ```
 Be aware that all queues are under the same exchange, it's up to you to set the correct routing for callbacks.
 #### Lifecycle events
-There are also couple of lifecycle events implemented: before_consume and after_consume. You can use them for any additional work you need to do before or after message been consumed. For example, reopen database connection for it not to be closed by timeout as a consumer is a long-running process: 
+There are also couple of lifecycle events implemented: before_consume, after_consume, before_publish, after_publish. You can use them for any additional work you need to do before or after message been consumed/published. For example, reopen database connection for it not to be closed by timeout as a consumer is a long-running process: 
 ```php
 <?php
 // config/main.php

--- a/components/Producer.php
+++ b/components/Producer.php
@@ -87,7 +87,7 @@ class Producer extends BaseRabbitMQ implements ProducerInterface
                 'amqp' => [
                     'body' => $msg->getBody(),
                     'routingkeys' => $routingKey,
-                    'properties' => $msg->get_properties(),
+                    'properties' => array_intersect_key($msg->get_properties(), $additionalProperties),
                     'headers' => $msg->has('application_headers') ? $msg->get('application_headers')->getNativeData() : $headers,
                 ],
             ], $this->logger['category']);

--- a/components/Producer.php
+++ b/components/Producer.php
@@ -76,11 +76,6 @@ class Producer extends BaseRabbitMQ implements ProducerInterface
 
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$routingKey);
 
-        \Yii::$app->rabbitmq->trigger(RabbitMQPublisherEvent::AFTER_PUBLISH, new RabbitMQPublisherEvent([
-            'message' => $msg,
-            'producer' => $this,
-        ]));
-
         if ($this->logger['enable']) {
             \Yii::info([
                 'info' => 'AMQP message published',
@@ -92,5 +87,10 @@ class Producer extends BaseRabbitMQ implements ProducerInterface
                 ],
             ], $this->logger['category']);
         }
+
+        \Yii::$app->rabbitmq->trigger(RabbitMQPublisherEvent::AFTER_PUBLISH, new RabbitMQPublisherEvent([
+            'message' => $msg,
+            'producer' => $this,
+        ]));
     }
 }

--- a/components/Producer.php
+++ b/components/Producer.php
@@ -69,14 +69,14 @@ class Producer extends BaseRabbitMQ implements ProducerInterface
             $msg->set('application_headers', $headersTable);
         }
 
-        \Yii::$app->rabbitmq->trigger(RabbitMQPublishEvent::BEFORE_PUBLISH, new RabbitMQPublishEvent([
+        \Yii::$app->rabbitmq->trigger(RabbitMQPublisherEvent::BEFORE_PUBLISH, new RabbitMQPublisherEvent([
             'message' => $msg,
             'producer' => $this,
         ]));
 
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$routingKey);
 
-        \Yii::$app->rabbitmq->trigger(RabbitMQPublishEvent::AFTER_PUBLISH, new RabbitMQPublishEvent([
+        \Yii::$app->rabbitmq->trigger(RabbitMQPublisherEvent::AFTER_PUBLISH, new RabbitMQPublisherEvent([
             'message' => $msg,
             'producer' => $this,
         ]));

--- a/components/Producer.php
+++ b/components/Producer.php
@@ -85,10 +85,10 @@ class Producer extends BaseRabbitMQ implements ProducerInterface
             \Yii::info([
                 'info' => 'AMQP message published',
                 'amqp' => [
-                    'body' => $msgBody,
+                    'body' => $msg->getBody(),
                     'routingkeys' => $routingKey,
-                    'properties' => $additionalProperties,
-                    'headers' => $headers,
+                    'properties' => $msg->get_properties(),
+                    'headers' => $msg->has('application_headers') ? $msg->get('application_headers')->getNativeData() : $headers,
                 ],
             ], $this->logger['category']);
         }

--- a/components/Producer.php
+++ b/components/Producer.php
@@ -68,7 +68,19 @@ class Producer extends BaseRabbitMQ implements ProducerInterface
             $headersTable = new AMQPTable($headers);
             $msg->set('application_headers', $headersTable);
         }
+
+        \Yii::$app->rabbitmq->trigger(RabbitMQPublishEvent::BEFORE_PUBLISH, new RabbitMQPublishEvent([
+            'message' => $msg,
+            'producer' => $this,
+        ]));
+
         $this->getChannel()->basic_publish($msg, $this->exchangeOptions['name'], (string)$routingKey);
+
+        \Yii::$app->rabbitmq->trigger(RabbitMQPublishEvent::AFTER_PUBLISH, new RabbitMQPublishEvent([
+            'message' => $msg,
+            'producer' => $this,
+        ]));
+
         if ($this->logger['enable']) {
             \Yii::info([
                 'info' => 'AMQP message published',

--- a/components/RabbitMQPublisherEvent.php
+++ b/components/RabbitMQPublisherEvent.php
@@ -18,5 +18,5 @@ class RabbitMQPublisherEvent extends Event
     /**
      * @var Consumer
      */
-    public $publisher;
+    public $producer;
 }

--- a/components/RabbitMQPublisherEvent.php
+++ b/components/RabbitMQPublisherEvent.php
@@ -5,7 +5,7 @@ namespace mikemadisonweb\rabbitmq\components;
 use PhpAmqpLib\Message\AMQPMessage;
 use yii\base\Event;
 
-class RabbitMQPublishEvent extends Event
+class RabbitMQPublisherEvent extends Event
 {
     const BEFORE_PUBLISH = 'before_publish';
     const AFTER_PUBLISH  = 'after_publish';

--- a/components/RabbitMQPublisherEvent.php
+++ b/components/RabbitMQPublisherEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace mikemadisonweb\rabbitmq\components;
+
+use PhpAmqpLib\Message\AMQPMessage;
+use yii\base\Event;
+
+class RabbitMQPublishEvent extends Event
+{
+    const BEFORE_PUBLISH = 'before_publish';
+    const AFTER_PUBLISH  = 'after_publish';
+
+    /**
+     * @var AMQPMessage
+     */
+    public $message;
+
+    /**
+     * @var Consumer
+     */
+    public $publisher;
+}


### PR DESCRIPTION
Hello,

First thanks for your work, it's really useful for me.

I submitting this pull request because i was missing event before publish and after publish to alter message before sending it to rabbitMQ.

I'm explaining my use case, I've got a bunch of micro-service exchanging with each other via http request or messages. I want to follow all workload create on all the micro-service by a specific request. To do so i've created a tracking component which does the following job: 
- Check if the specific micro-service was call by http, if so try to get the http header with the request id which made that call, and load that id
- Check if the micro-service was trigger by a rabbit MQ message (in that case i'm using the before_consume event) and check message header to see if there is the request id
- If there is no request id define create one
- Register on all http event on before_send to add the http header with the request id (so every other micros service i'm calling will no my current request id)
- Register on all rabbitMq producer to add the request id header on every message before sending them (that's where i'm missing the before_publish event).

I could have use the add header on every publish call but in that case i need to change all my code and one day if i want to remove that i need to do the change once again, so that's why i'm doing this pull request to add before_publish and after_publish events.

Regards,
Macfly

 