### PR TITLE
Upgrade php-amqplib to ^2.9 / add channel_rpc_timeout option

### DIFF
--- a/Configuration.php
+++ b/Configuration.php
@@ -42,6 +42,7 @@ class Configuration extends Component
                 'ssl_context' => null,
                 'keepalive' => false,
                 'heartbeat' => 0,
+                'channel_rpc_timeout' => 0.0
             ],
         ],
         'exchanges' => [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ php composer.phar require mikemadisonweb/yii2-rabbitmq
 ```
 or add
 ```json
-"mikemadisonweb/yii2-rabbitmq": "^2.0.0"
+"mikemadisonweb/yii2-rabbitmq": "^2.1.1"
 ```
 to the require section of your `composer.json` file.
 
@@ -258,6 +258,7 @@ $rabbitmq_defaults = [
                 'ssl_context' => null,
                 'keepalive' => false,
                 'heartbeat' => 0,
+                'channel_rpc_timeout' => 1
             ],
         ],
         'exchanges' => [

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ $rabbitmq_defaults = [
                 'ssl_context' => null,
                 'keepalive' => false,
                 'heartbeat' => 0,
-                'channel_rpc_timeout' => 1
+                'channel_rpc_timeout' => 0.0
             ],
         ],
         'exchanges' => [

--- a/components/AbstractConnectionFactory.php
+++ b/components/AbstractConnectionFactory.php
@@ -43,7 +43,8 @@ class AbstractConnectionFactory
             $this->_parameters['read_write_timeout'],
             $this->_parameters['ssl_context'],
             $this->_parameters['keepalive'],
-            $this->_parameters['heartbeat']
+            $this->_parameters['heartbeat'],
+            $this->_parameters['channel_rpc_timeout']
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^7.0",
     "yiisoft/yii2": "^2.0",
-    "php-amqplib/php-amqplib": "^2.7"
+    "php-amqplib/php-amqplib": "^2.9"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.4",


### PR DESCRIPTION
These changes:

- upgrade php-amqplib to ^2.9
- add channel_rpc_timeout option to the Configuration 
- adapts AbstractConnectionFactory to construct new Connections with the configured channel_rpc_timeout

Without these changes, the package will block fpm processes if rabbitmq is in a high watermark state and connections cannot be closed (since they are blocked). See: https://github.com/php-amqplib/php-amqplib/issues/88

Unit Tests where passing, based on the [php-amqplib Changelog](https://github.com/php-amqplib/php-amqplib/blob/master/CHANGELOG.md) no breaking changes have been introduced between 2.7 (formerly used) and 2.9. Anything else to take care of?

Cheers!