### PR TITLE
Example code for closing and opening the database is not performant

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,12 @@ return [
         'rabbitmq'  => [
             // ...
             'on before_consume' => function ($event) {
-                if (isset(\Yii::$app->db)) {
-                    $db = \Yii::$app->db;
-                    if ($db->getIsActive()) {
-                        $db->close();
+                if (isset(\Yii::$app->db) && \Yii::$app->db->isActive) {
+                    try {
+                        Yii::$app->db->createCommand('SELECT 1')->query();
+                    } catch (\yii\db\Exception $exception) {
+                        Yii::$app->db->close();
                     }
-                    $db->open();
                 }
             },
         ],

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ return [
             'on before_consume' => function ($event) {
                 if (isset(\Yii::$app->db) && \Yii::$app->db->isActive) {
                     try {
-                        Yii::$app->db->createCommand('SELECT 1')->query();
+                        \Yii::$app->db->createCommand('SELECT 1')->query();
                     } catch (\yii\db\Exception $exception) {
-                        Yii::$app->db->close();
+                        \Yii::$app->db->close();
                     }
                 }
             },

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you need several consumers you can list respective entries in the configurati
 
 Be sure that all queues and exchanges are defined in corresponding bindings, it's up to you to set up correct message routing.
 #### Lifecycle events
-There are also some lifecycle events implemented: before_consume, after_consume, before_publish, after_publish. You can use them for any additional work you need to do before or after message been consumed/published. For example, reopen database connection for it not to be closed by a timeout as a consumer is a long-running process: 
+There are also some lifecycle events implemented: before_consume, after_consume, before_publish, after_publish. You can use them for any additional work you need to do before or after message been consumed/published. For example, make sure that Yii knows the database connection has been closed by a timeout as a consumer is a long-running process: 
 ```php
 <?php
 // config/main.php
@@ -128,7 +128,7 @@ return [
         'rabbitmq'  => [
             // ...
             'on before_consume' => function ($event) {
-                if (isset(\Yii::$app->db) && \Yii::$app->db->isActive) {
+                if (\Yii::$app->has('db') && \Yii::$app->db->isActive) {
                     try {
                         \Yii::$app->db->createCommand('SELECT 1')->query();
                     } catch (\yii\db\Exception $exception) {


### PR DESCRIPTION
The README.md specifies an example to close and reopen the database connection to make sure the connection isn't timed out. The way this is done is not very performant.

This changes the example to do a query (only when the database is already connected), and when this fails, it closes the connection. It actually is already closed, but this also makes sure that `Yii:$app->db` knows that. When some code later on makes a query to the database, Yii will automatically reopen the connection since it can see now that we are not already connected.

The previous example always disconnects and reconnects, even no database call is made in the consumer.

I see a x3 performance with this change.