### PR TITLE
Fix line breaks in logger

### DIFF
--- a/components/Logger.php
+++ b/components/Logger.php
@@ -114,10 +114,10 @@ class Logger
     public function printInfo($message, $color = Console::FG_YELLOW)
     {
         if (Console::streamSupportsAnsiColors(\STDOUT)) {
-            $message = Console::ansiFormat($message, [$color]) . "\n";
+            $message = Console::ansiFormat($message, [$color]);
         }
 
-        return Console::stdout($message);
+        return Console::output($message);
     }
 
     /**


### PR DESCRIPTION
I have a consumer launched by supervisor:
```
[program:*******-rabbitmq-consume]
command=/usr/bin/php /var/www/*******/main2/yii rabbitmq/consume default
numprocs=1
stdout_logfile=/var/log/******-rabbitmq-consume.log
stdout_logfile_maxbytes=50MB
stdout_logfile_backups=50
stdout_capture_maxbytes=1MB
autostart=true
autorestart=true
```

and it gets logged without linebreaks.
Yii2 Console::output() adds valid line break.