### PR TITLE
Map controller to console application only

### DIFF
--- a/DependencyInjection.php
+++ b/DependencyInjection.php
@@ -176,6 +176,8 @@ class DependencyInjection implements BootstrapInterface
      */
     private function addControllers(Application $app)
     {
-        $app->controllerMap[Configuration::EXTENSION_CONTROLLER_ALIAS] = RabbitMQController::class;
+	    if($app instanceof \yii\console\Application) {
+		    $app->controllerMap[Configuration::EXTENSION_CONTROLLER_ALIAS] = RabbitMQController::class;
+	    }
     }
 }


### PR DESCRIPTION
The RabbitMQ extension may be used not only in console application, but in other kind of applications aswell. For example, you may want to add it to common. In this case, controllers were mapped to every application, so its controllers and actions are exposed to web, which is usually not what you want.

This patch fixes issue by limiting controller mapping to console application only.